### PR TITLE
Fix for unwanted PHP notice on the frontend

### DIFF
--- a/lockdown-wp-admin.php
+++ b/lockdown-wp-admin.php
@@ -573,7 +573,8 @@ class WP_LockAuth
 		$request_url = str_replace( $blog_url, '', $current_url );
 		$request_url = str_replace('index.php/', '', $request_url);
 		
-		list( $base, $query ) = explode( '?', $request_url, 2 );
+		$url_parts = explode( '?', $request_url, 2 );
+		$base = $url_parts[0];
 		
 		// Remove trailing slash
 		$base = rtrim($base,"/");


### PR DESCRIPTION
A simplified version of the solution I posted on wordpress.org to removing a PHP notice.
http://wordpress.org/support/topic/unwanted-php-notice-on-the-frontend

It seems that $query isn't used, so no need to use php list.
