### PR TITLE
Apply filter to $four_tpl

### DIFF
--- a/lockdown-wp-admin.php
+++ b/lockdown-wp-admin.php
@@ -640,7 +640,7 @@ class WP_LockAuth
 		wp_dequeue_style( 'admin-bar' );
 
 		// Template
-		$four_tpl = get_404_template();
+		$four_tpl = apply_filters('LD_404', get_404_template());
 
 		// Handle the admin bar
 		@define('APP_REQUEST', TRUE);


### PR DESCRIPTION
Some themes have a **Template Wrapper** (e.g. [Roots Theme](https://github.com/retlehs/roots)) that ignored by <code>get_404_template()</code> function and may not display _header_ or _footer_. But now, we can change path from <code>404.php</code> to our <code>wrapper.php</code>.
