### PR TITLE
Reduce init priority to 20

### DIFF
--- a/lockdown-wp-admin.php
+++ b/lockdown-wp-admin.php
@@ -728,7 +728,7 @@ function ld_setup_auth()
 	return $auth_obj;
 }
 
-add_action('init', 'ld_setup_auth');
+add_action('init', 'ld_setup_auth', 20);
 
 /* End of file: lockdown-wp-admin.php */
 /* Code is poetry. */


### PR DESCRIPTION
I'm one of the developers of [Clef](http://wordpress.org/plugins/wpclef). We've had bug reports (clef/wordpress#120) that Clef doesn't show up when users are using Lockdown-WP-Admin to hide their login page.

I did some digging and it looks like this is because we're both using the default priority of 10 for the init action. Because of randomness, Lockdown-WPAdmin gets initialized before Clef, and includes the `wp-login.php` file before we have the time to hook into it.

There could be an argument made for both of us moving our priority forward or backward, but after some thinking I actually think it makes the most sense for Lockdown-WPAdmin to. After doing some research, there are other login plugins that hook at this time — which are excluded from use with the current Lockdown-WPAdmin priority. Delaying y'alls hook to 20 (or 99) will allow more functionality which _should_ be on the login page to actually be there.

What do you think?
